### PR TITLE
Support parsing sby file from stdin

### DIFF
--- a/sbysrc/sby_core.py
+++ b/sbysrc/sby_core.py
@@ -16,7 +16,7 @@
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #
 
-import os, re, resource
+import os, re, resource, sys
 import subprocess, fcntl
 from shutil import copyfile
 from select import select
@@ -157,7 +157,6 @@ class SbyJob:
         self.logprefix = "SBY [%s]" % self.workdir
         self.summary = list()
 
-        os.makedirs(workdir)
         self.logfile = open("%s/logfile.txt" % workdir, "w")
 
         for line in early_logs:
@@ -167,7 +166,7 @@ class SbyJob:
         mode = None
         key = None
 
-        with open(filename, "r") as f:
+        with (open(filename, "r") if filename else sys.stdin) as f:
             with open("%s/config.sby" % workdir, "w") as cfgfile:
                 pycode = None
                 for line in f:


### PR DESCRIPTION
Implements #1 .

This is a minimum-modification approach to parsing an sby file from stdin. I tested it on the demo .sby files in the repo as well as on two of my own .sby files.

The major design choice was to use a temporary directory as the working directory and to remove it when finished. I considered using a directory called something like "sby" or just leaving the temp dir intact - either would be easy to implement.

I'm not totally in love with how the code to make this feature interact with '-f' came out - let me know if you'd like that done a different way.